### PR TITLE
Replace Pod Update() with Pod Patch() to update Pod in place

### DIFF
--- a/pkg/pod/entrypoint.go
+++ b/pkg/pod/entrypoint.go
@@ -25,6 +25,9 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -168,15 +171,29 @@ func UpdateReady(kubeclient kubernetes.Interface, pod corev1.Pod) error {
 		return fmt.Errorf("error getting Pod %q when updating ready annotation: %w", pod.Name, err)
 	}
 
-	// Update the Pod's "READY" annotation to signal the first step to
-	// start.
-	if newPod.ObjectMeta.Annotations == nil {
-		newPod.ObjectMeta.Annotations = map[string]string{}
+	updatedPod := newPod.DeepCopy()
+
+	if updatedPod.ObjectMeta.Annotations == nil {
+		updatedPod.ObjectMeta.Annotations = map[string]string{}
 	}
-	if newPod.ObjectMeta.Annotations[readyAnnotation] != readyAnnotationValue {
-		newPod.ObjectMeta.Annotations[readyAnnotation] = readyAnnotationValue
-		if _, err := kubeclient.CoreV1().Pods(newPod.Namespace).Update(newPod); err != nil {
-			return fmt.Errorf("error adding ready annotation to Pod %q: %w", pod.Name, err)
+
+	oldAnnotations := newPod.ObjectMeta.Annotations
+	newAnnotations := updatedPod.ObjectMeta.Annotations
+
+	if oldAnnotations == nil {
+		oldAnnotations = map[string]string{}
+	}
+
+	if newAnnotations[readyAnnotation] != readyAnnotationValue {
+		newAnnotations[readyAnnotation] = readyAnnotationValue
+		patchData, patchDataErr := preparePatchBytesforPod(pod.Namespace, pod.Name, *newPod, *updatedPod)
+		if patchDataErr != nil {
+			return fmt.Errorf("error preparing patch data for annotations in Pod %q: %w", pod.Name, patchDataErr)
+		}
+
+		_, patchOperationErr := kubeclient.CoreV1().Pods(newPod.Namespace).Patch(pod.Name, types.StrategicMergePatchType, patchData, "annotations")
+		if patchOperationErr != nil {
+			return fmt.Errorf("error adding ready annotation to Pod %q: %w", pod.Name, patchOperationErr)
 		}
 	}
 	return nil
@@ -191,25 +208,32 @@ func StopSidecars(nopImage string, kubeclient kubernetes.Interface, pod corev1.P
 	}
 
 	updated := false
-	if newPod.Status.Phase == corev1.PodRunning {
-		for _, s := range newPod.Status.ContainerStatuses {
+	updatedPod := newPod.DeepCopy()
+	if updatedPod.Status.Phase == corev1.PodRunning {
+		for _, s := range updatedPod.Status.ContainerStatuses {
 			// Stop any running container that isn't a step.
 			// An injected sidecar container might not have the
 			// "sidecar-" prefix, so we can't just look for that
 			// prefix.
 			if !IsContainerStep(s.Name) && s.State.Running != nil {
-				for j, c := range newPod.Spec.Containers {
+				for j, c := range updatedPod.Spec.Containers {
 					if c.Name == s.Name && c.Image != nopImage {
 						updated = true
-						newPod.Spec.Containers[j].Image = nopImage
+						updatedPod.Spec.Containers[j].Image = nopImage
 					}
 				}
 			}
 		}
 	}
 	if updated {
-		if _, err := kubeclient.CoreV1().Pods(newPod.Namespace).Update(newPod); err != nil {
-			return fmt.Errorf("error stopping sidecars of Pod %q: %w", pod.Name, err)
+		patchData, patchDataErr := preparePatchBytesforPod(pod.Namespace, pod.Name, *newPod, *updatedPod)
+		if patchDataErr != nil {
+			return fmt.Errorf("error preparing patch data for images in Pod %q: %w", pod.Name, patchDataErr)
+		}
+
+		_, patchOperationErr := kubeclient.CoreV1().Pods(newPod.Namespace).Patch(pod.Name, types.StrategicMergePatchType, patchData, "images")
+		if patchOperationErr != nil {
+			return fmt.Errorf("error adding ready images to Pod %q: %w", pod.Name, patchOperationErr)
 		}
 	}
 	return nil
@@ -227,7 +251,7 @@ func IsSidecarStatusRunning(tr *v1beta1.TaskRun) bool {
 	return false
 }
 
-// isContainerStep returns true if the container name indicates that it
+// IsContainerStep returns true if the container name indicates that it
 // represents a step.
 func IsContainerStep(name string) bool { return strings.HasPrefix(name, stepPrefix) }
 
@@ -238,6 +262,27 @@ func isContainerSidecar(name string) bool { return strings.HasPrefix(name, sidec
 // trimStepPrefix returns the container name, stripped of its step prefix.
 func trimStepPrefix(name string) string { return strings.TrimPrefix(name, stepPrefix) }
 
-// trimSidecarPrefix returns the container name, stripped of its sidecar
+// TrimSidecarPrefix returns the container name, stripped of its sidecar
 // prefix.
 func TrimSidecarPrefix(name string) string { return strings.TrimPrefix(name, sidecarPrefix) }
+
+// preparePatchBytesforPod compares the old and new Pod and creates a Patch data.
+func preparePatchBytesforPod(namespace, name string, oldPod, newPod corev1.Pod) ([]byte, error) {
+	oldData, err := json.Marshal(oldPod)
+	if err != nil {
+		return nil, fmt.Errorf("failed to Marshal old pod %q/%q: %v", namespace, name, err)
+	}
+
+	newData, err := json.Marshal(newPod)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to Marshal new pod %q/%q: %v", namespace, name, err)
+	}
+
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, corev1.Pod{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to CreateTwoWayMergePatch for pod %q/%q: %v", namespace, name, err)
+	}
+
+	return patchBytes, nil
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
